### PR TITLE
use class so configure will work in rails initializer

### DIFF
--- a/lib/pipeline_deals.rb
+++ b/lib/pipeline_deals.rb
@@ -6,7 +6,7 @@ require_relative 'pipeline_deals/resources/definitions'
 
 Dir[File.dirname(__FILE__) + '/resources/*.rb'].each {|file| p "requring #{file}"; require file }
 
-module PipelineDeals
+class PipelineDeals
   class << self
     attr_accessor :app_key, :api_key, :app_version
 

--- a/lib/pipeline_deals/admin_resource.rb
+++ b/lib/pipeline_deals/admin_resource.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class AdminResource < Resource
     self.prefix = "/api/v3/admin/"
   end

--- a/lib/pipeline_deals/collection.rb
+++ b/lib/pipeline_deals/collection.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Collection < ActiveResource::Collection
     attr_accessor :pagination
     def initialize(parsed = {})

--- a/lib/pipeline_deals/resource.rb
+++ b/lib/pipeline_deals/resource.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Resource < ActiveResource::Base
     self.site = "https://api.pipelinedeals.com"
     self.prefix = "/api/v3/"

--- a/lib/pipeline_deals/resources/account.rb
+++ b/lib/pipeline_deals/resources/account.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Account < PipelineDeals::Resource
     include ActiveResource::Singleton
     def self.account(options = {})

--- a/lib/pipeline_deals/resources/calendar_entry.rb
+++ b/lib/pipeline_deals/resources/calendar_entry.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class CalendarEntry < PipelineDeals::Resource
     belongs_to :category, class_name: PipelineDeals::EventCategory, foreign_key: :category_id
     belongs_to :owner, class_name: PipelineDeals::User, foreign_key: :owner_id

--- a/lib/pipeline_deals/resources/company.rb
+++ b/lib/pipeline_deals/resources/company.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Company < PipelineDeals::Resource
     has_many :deals, class_name: PipelineDeals::Deal
     has_many :people, class_name: PipelineDeals::Person

--- a/lib/pipeline_deals/resources/company_custom_field_label.rb
+++ b/lib/pipeline_deals/resources/company_custom_field_label.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class CompanyCustomFieldLabel < PipelineDeals::AdminResource
     has_many :custom_field_label_dropdown_entries, class_name: PipelineDeals::CustomFieldLabelDropdownEntry
   end

--- a/lib/pipeline_deals/resources/custom_field_label_dropdown_entry.rb
+++ b/lib/pipeline_deals/resources/custom_field_label_dropdown_entry.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class CustomFieldLabelDropdownEntry < PipelineDeals::AdminResource
   end
 end

--- a/lib/pipeline_deals/resources/deal.rb
+++ b/lib/pipeline_deals/resources/deal.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Deal < PipelineDeals::Resource
     has_many :people, class_name: PipelineDeals::Person
     has_many :documents, class_name: PipelineDeals::Document

--- a/lib/pipeline_deals/resources/deal_custom_field_label.rb
+++ b/lib/pipeline_deals/resources/deal_custom_field_label.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class DealCustomFieldLabel < PipelineDeals::AdminResource
     has_many :custom_field_label_dropdown_entries, class_name: PipelineDeals::CustomFieldLabelDropdownEntry
   end

--- a/lib/pipeline_deals/resources/deal_stage.rb
+++ b/lib/pipeline_deals/resources/deal_stage.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class DealStage < PipelineDeals::AdminResource
   end
 end

--- a/lib/pipeline_deals/resources/definitions.rb
+++ b/lib/pipeline_deals/resources/definitions.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class DealStage < PipelineDeals::AdminResource; end
   class NoteCategory < PipelineDeals::AdminResource; end
   class DealCustomFieldLabel < PipelineDeals::AdminResource; end

--- a/lib/pipeline_deals/resources/document.rb
+++ b/lib/pipeline_deals/resources/document.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Document < PipelineDeals::Resource
     belongs_to :user, class_name: PipelineDeals::User
     belongs_to :deal, class_name: PipelineDeals::Deal

--- a/lib/pipeline_deals/resources/event_category.rb
+++ b/lib/pipeline_deals/resources/event_category.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class EventCategory < PipelineDeals::AdminResource
   end
 end

--- a/lib/pipeline_deals/resources/lead_source.rb
+++ b/lib/pipeline_deals/resources/lead_source.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class LeadSource < PipelineDeals::AdminResource
   end
 end

--- a/lib/pipeline_deals/resources/lead_status.rb
+++ b/lib/pipeline_deals/resources/lead_status.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class LeadStatus < PipelineDeals::AdminResource
   end
 end

--- a/lib/pipeline_deals/resources/note.rb
+++ b/lib/pipeline_deals/resources/note.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Note < PipelineDeals::Resource
     belongs_to :note_category, class_name: PipelineDeals::NoteCategory
     belongs_to :company, class_name: PipelineDeals::Company

--- a/lib/pipeline_deals/resources/note_category.rb
+++ b/lib/pipeline_deals/resources/note_category.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class NoteCategory < PipelineDeals::AdminResource
   end
 end

--- a/lib/pipeline_deals/resources/person.rb
+++ b/lib/pipeline_deals/resources/person.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class Person < PipelineDeals::Resource
     has_many :deals, class_name: PipelineDeals::Deal
     has_many :documents, class_name: PipelineDeals::Document

--- a/lib/pipeline_deals/resources/person_custom_field_label.rb
+++ b/lib/pipeline_deals/resources/person_custom_field_label.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class PersonCustomFieldLabel < PipelineDeals::AdminResource
     has_many :custom_field_label_dropdown_entries, class_name: PipelineDeals::CustomFieldLabelDropdownEntry
   end

--- a/lib/pipeline_deals/resources/predefined_contacts_tags.rb
+++ b/lib/pipeline_deals/resources/predefined_contacts_tags.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class PredefinedContactsTag < PipelineDeals::AdminResource
   end
 end

--- a/lib/pipeline_deals/resources/user.rb
+++ b/lib/pipeline_deals/resources/user.rb
@@ -1,4 +1,4 @@
-module PipelineDeals
+class PipelineDeals
   class User < PipelineDeals::Resource
     has_many :deals, class_name: PipelineDeals::Deal
     has_many :people, class_name: PipelineDeals::Person

--- a/lib/pipeline_deals/version.rb
+++ b/lib/pipeline_deals/version.rb
@@ -1,3 +1,3 @@
-module PipelineDeals
+class PipelineDeals
   VERSION = "0.3.0"
 end


### PR DESCRIPTION
Turns out, that using a module, you can't use this configure method in a rails initializer.  Using a class works fine.
